### PR TITLE
Show the command the code is trying to run.

### DIFF
--- a/src/markdoc/cli/commands.py
+++ b/src/markdoc/cli/commands.py
@@ -235,7 +235,11 @@ def sync_html(config, args):
     
     log.debug(subprocess.list2cmdline(display_cmd))
     
-    subprocess.check_call(command)
+    try:
+        subprocess.check_call(command)
+    except:
+        print "Failed running the command: "+command
+        raise
     
     log.debug('rsync completed')
 


### PR DESCRIPTION
This is no longer needed in Python 3, as subprocess will report the command it's trying to execute that.